### PR TITLE
Fix .gitignore entry for mvcommon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-./mvncommon
+./mvcommon
 /tmp


### PR DESCRIPTION
## Summary
- correct `.gitignore` so it ignores `mvcommon` instead of `mvncommon`

## Testing
- `go test ./...` *(fails: fmt.Println arg list ends with redundant newline)*

------
https://chatgpt.com/codex/tasks/task_e_6848243c5634832f8217eb10f3e23c7d