### PR TITLE
Add Docker support to GoReleaser

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -20,6 +21,13 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v5
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY mvcommon /mvcommon
+ENTRYPOINT ["/mvcommon"]

--- a/cmd/mvcommon/main.go
+++ b/cmd/mvcommon/main.go
@@ -85,7 +85,7 @@ func interactiveFileSelection(files []string, stopWords []string, trim string, m
 		// Find common prefix
 		folderName := mvcommon.CommonPrefixSplit(selectedFiles, stopWords, trim, minMatch)
 		if folderName == "" {
-			fmt.Println("Error: No common prefix found!\n")
+			fmt.Println("Error: No common prefix found!")
 		} else {
 			fmt.Printf("Will move the files to %q\n\n", folderName)
 		}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,14 +1,16 @@
+version: 2
 project_name: mvcommon
 builds:
-  -
-    id: "mvcommon"
-    binary: "mvcommon"
+  - id: mvcommon
+    binary: mvcommon
     dir: cmd/mvcommon
     env:
       - CGO_ENABLED=0
+    goos: [linux, windows, darwin]
+    goarch: [amd64, arm64]
+    flags: ["-trimpath"]
 archives:
-  -
-    format_overrides:
+  - format_overrides:
       - goos: windows
         format: zip
 checksum:
@@ -22,8 +24,7 @@ changelog:
       - '^docs:'
       - '^test:'
 nfpms:
-  -
-    vendor: Ubels Software Development
+  - vendor: Ubels Software Development
     homepage: https://github.com/arran4/
     maintainer: Arran Ubels <arran@ubels.com.au>
     description: NA
@@ -37,3 +38,24 @@ nfpms:
     release: 1
     section: default
     priority: extra
+
+# Build and publish multi-arch docker images
+# Requires permissions to push to ghcr.io
+
+dockers:
+  - image_templates:
+      - ghcr.io/arran4/mvcommon:{{ .Tag }}-{{ .Arch }}
+    dockerfile: Dockerfile
+    use: buildx
+    goos: linux
+    goarch: [amd64, arm64]
+
+docker_manifests:
+  - name_template: ghcr.io/arran4/mvcommon:{{ .Tag }}
+    image_templates:
+      - ghcr.io/arran4/mvcommon:{{ .Tag }}-amd64
+      - ghcr.io/arran4/mvcommon:{{ .Tag }}-arm64
+  - name_template: ghcr.io/arran4/mvcommon:latest
+    image_templates:
+      - ghcr.io/arran4/mvcommon:{{ .Tag }}-amd64
+      - ghcr.io/arran4/mvcommon:{{ .Tag }}-arm64


### PR DESCRIPTION
## Summary
- add Dockerfile for container publishing
- extend goreleaser config with docker and multi-arch support
- let GitHub workflow login to ghcr.io before running GoReleaser
- fix redundant newline in main.go so `go vet` passes

## Testing
- `go test ./...`
- `yamllint -d relaxed goreleaser.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684eacac502c832fb9cdd8ed92c4b3a6