### PR TITLE
Fix go vet newline warning

### DIFF
--- a/cmd/mvcommon/main.go
+++ b/cmd/mvcommon/main.go
@@ -85,9 +85,10 @@ func interactiveFileSelection(files []string, stopWords []string, trim string, m
 		// Find common prefix
 		folderName := mvcommon.CommonPrefixSplit(selectedFiles, stopWords, trim, minMatch)
 		if folderName == "" {
-			fmt.Println("Error: No common prefix found!")
+			fmt.Fprintln(os.Stderr, "Error: No common prefix found!")
 		} else {
-			fmt.Printf("Will move the files to %q\n\n", folderName)
+			fmt.Printf("Will move the files to %q\n", folderName)
+			fmt.Println()
 		}
 
 		fmt.Println("For the following files:")


### PR DESCRIPTION
## Summary
- fix `go vet` newline warning by using `fmt.Fprintln` and splitting newline output
- keep `go vet` happy on Go 1.23

## Testing
- `go vet ./...`
- `golint ./...` (fails: exported declarations need comments)


------
https://chatgpt.com/codex/tasks/task_e_6854de47fa98832faa8d5c249be84481