### PR TITLE
Fix newline warnings

### DIFF
--- a/cmd/mvcommon/main.go
+++ b/cmd/mvcommon/main.go
@@ -81,13 +81,15 @@ func interactiveFileSelection(files []string, stopWords []string, trim string, m
 	for {
 
 		// Print files with indices
-		fmt.Println("\nInteractive Mode Enabled:")
+		fmt.Println()
+		fmt.Println("Interactive Mode Enabled:")
 		// Find common prefix
 		folderName := mvcommon.CommonPrefixSplit(selectedFiles, stopWords, trim, minMatch)
 		if folderName == "" {
 			fmt.Println("Error: No common prefix found!")
 		} else {
-			fmt.Printf("Will move the files to %q\n\n", folderName)
+			fmt.Printf("Will move the files to %q\n", folderName)
+			fmt.Println()
 		}
 
 		fmt.Println("For the following files:")
@@ -98,7 +100,8 @@ func interactiveFileSelection(files []string, stopWords []string, trim string, m
 		var nextSelectedFiles = make([]string, 0, len(selectedFiles))
 
 		// Prompt user for confirmation or range input
-		fmt.Println("\nEnter file numbers to include (e.g., 1,2,3 or 1-3,5-6) or press 'a' to confirm all, 'r' to reset:")
+		fmt.Println()
+		fmt.Println("Enter file numbers to include (e.g., 1,2,3 or 1-3,5-6) or press 'a' to confirm all, 'r' to reset:")
 		for {
 			fmt.Print("Your choice: ")
 			input, err := reader.ReadString('\n')


### PR DESCRIPTION
## Summary
- fix redundant newline warnings in interactive prompt output

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854dd3c94ec832f81305ed54da2b116